### PR TITLE
Release v1.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,7 @@ jobs:
   create-release:
     needs: [build-windows, build-linux, build-macos]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    if: startsWith(github.ref, 'refs/tags/')
     
     steps:
     - uses: actions/checkout@v4
@@ -165,12 +165,6 @@ jobs:
       with:
         name: csvlotte-linux
         path: dist/linux/
-    
-    - name: Download macOS artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: csvlotte-macos
-        path: dist/macos/
     
     - name: Download macOS artifacts
       uses: actions/download-artifact@v4

--- a/installer.iss
+++ b/installer.iss
@@ -3,7 +3,7 @@
 
 [Setup]
 AppName=CSVLotte
-AppVersion=1.0.1
+AppVersion=1.0.2
 AppPublisher=Lukas Waschul
 AppPublisherURL=https://github.com/your-username/csvlotte
 AppSupportURL=https://github.com/your-username/csvlotte/issues

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "csvlotte"
-version = "1.0.1"
+version = "1.0.2"
 description = ""
 authors = [
     {name = "Lukas Waschul",email = "xy@xy.com"}


### PR DESCRIPTION
This pull request includes updates to the build workflow and version bumping for the `csvlotte` project. The most significant changes involve refining the release process in the GitHub Actions workflow and updating the application version across relevant files.

### Updates to the build workflow:
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L152-R152): Modified the `if` condition for the `create-release` job to trigger only on tags, removing the condition for the `main` branch. Additionally, removed the step for downloading macOS artifacts since it was redundant. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L152-R152) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L175-L180)

### Version bump:
* [`installer.iss`](diffhunk://#diff-72e96ba8fc218bf3c064839eb76a1c3fd565d88d921c7ab3205ba6d988fc4cf1L6-R6): Updated `AppVersion` from `1.0.1` to `1.0.2` to reflect the new release version.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the `version` field from `1.0.1` to `1.0.2` to maintain consistency across project files.